### PR TITLE
deleted link back to website because user is still on the website

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,7 +23,7 @@ function redirectToBlog() {
             .innerHTML = `<p>Hey, looks like this content has moved. Here is where you can find it: <a href='${url}'>${url}</a></p>`;
     } else {
         document.getElementById('page-error')
-            .innerHTML = `<p>Hey, looks like this page doesn't exist. <a href="{{ site.baseurl }}">Back to the site!</a></p>`;
+            .innerHTML = `<p>Hey, looks like this page doesn't exist</p>`;
     }
 }
 


### PR DESCRIPTION
Right now, the link does not direct the user anywhere – clicking the link keeps the user on the 404. Because the 404 page is on the site and not a separate page, I don't think the link is necessary