### PR TITLE
More direct Slack invite link

### DIFF
--- a/slack.html
+++ b/slack.html
@@ -13,45 +13,9 @@ redirect_from:
             meetups.  Each project has there own dedicated channel that is open to anyone.
         </p>
         <p>
-            Enter your email address below and you’ll receive an invite to join <em>codefordc.slack.com</em>.
+          <a href="https://join.slack.com/t/codefordc/shared_invite/enQtOTAwOTEzMDA1MTU5LWRjNjIyOWMzNDBlN2FhZjJhZWIwODAwNjAzODg0YjllZmMzNjM0MjViMmFmOWFhYTE2YjZhNGYyZmVmN2RmNzI" id="submitrequest" type="submit" class="btn btn-primary">
+              <img src="assets/slack.png" style="margin-right: 0.5rem;">Join Our Slack
+          </a>
         </p>
-        <div class="valid-feedback" id="success" style="display: none;">
-            <div class="usa-alert-body">
-                <h3 class="usa-alert-heading">Thanks!</h3>
-                <p class="usa-alert-text">Check your email for an invite.</p>
-            </div>
-        </div>
-        <form id="requestinvite" role="form">
-            <!-- <label for="email">Email Address</label> -->
-            <input id="email" name="email" type="email" placeholder="Email address">
-            <button id="submitrequest" type="submit" class="btn btn-primary">
-                <img src="assets/slack.png" style="margin-right: 0.5rem;">Join Our Slack
-            </button>
-        </form>
     </div>
 </div>
-<script type="text/javascript">
-    document.addEventListener("DOMContentLoaded", function (event) {
-        // Form validation
-        // $("#requestinvite").validator();
-
-        // Send message to Slack
-        $("#requestinvite").submit(function (event) {
-            event.preventDefault();
-            var payload = JSON.stringify({
-                "email": $("#email").val()
-            });
-            $.ajax({
-                url: "https://slackfordc.herokuapp.com/invite",
-                type: "POST",
-                data: payload,
-                contentType: "application/json",
-                success: function () {
-                    $("#email").val("");
-                    $("#success").show();
-                }
-            });
-        });
-    });
-
-</script>


### PR DESCRIPTION
This stops relying on a bespoke Heroku app to send invites and uses an [invite link](https://slack.com/help/articles/201330256#share-an-invite-link) to power things instead. The link can handle up to 2000 invites, Slack says. To date, we've sent just over 1900 invites, so this link should be usable for a number of years before it'll need to be swapped.

As a bonus, I won't get a Slack DM every time somebody accepts an invite.