### PR TITLE
Update donate.html

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -92,6 +92,8 @@ title: Donate to Code for DC
       amount = Math.round((amount + 0.00001) * 100) / 100;
       // Back to cents
       amount = amount * 100;
+      // Trim off any fractions of a cents
+      amount = Math.trunc(amount);
       document.getElementById('donationButton').textContent =
         'Make $' + amount / 100 + ' donation';
     };


### PR DESCRIPTION
This fixes a weird issue that sometimes happens when somebody selects the "cover fees" option. The calculation includes a tiny fraction of a cent, which Stripe does not like. Since the number of cents should always be an integer, this just truncates the amount.

This can be tested locally by submitting a $36 donation and checking the "cover fees" box. Run it with the line commented out, which should fail, and then again with the line back in.