### PR TITLE
modify google maps link

### DIFF
--- a/js/meetup.js
+++ b/js/meetup.js
@@ -32,7 +32,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 } else {
                   $("#next-location").html(
                       `
-                  <a href="https://www.google.com/maps/place/@${nextMeetup.venue.lat},-${nextMeetup.venue.lon},13z" target="_blank">${nextMeetup.venue.address_1}</a>
+                      <a href="https://www.google.com/maps/search/?api=1&query=${nextMeetup.venue.name}%2C%20${nextMeetup.venue.address_1}%2C%20${nextMeetup.venue.city}%2C%20${nextMeetup.venue.state}" target="_blank">${nextMeetup.venue.address_1}</a>
                       `
                   )
                 }
@@ -48,7 +48,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     } else {
                       $("#next-location").html(
                           `
-                      <a href="https://www.google.com/maps/place/@${futureMeetup.venue.lat},-${nextMeetup.venue.lon},13z" target="_blank">${nextMeetup.venue.address_1}</a>
+                      <a href="https://www.google.com/maps/search/?api=1&query=${futureMeetup.venue.name}%2C%20${futureMeetup.venue.address_1}%2C%20${futureMeetup.venue.city}%2C%20${futureMeetup.venue.state}" target="_blank">${futureMeetup.venue.address_1}</a>
                           `
                       )
                     }


### PR DESCRIPTION
this fixes #15 
the link for the event address doesn't work, the link generated for the next meetup looks like:
`https://www.google.com/maps/place/@38.897682189941406,--77.02645874023438,13z`
and goes to this page:
<img width="1228" alt="Screen Shot 2023-05-12 at 8 23 01 AM" src="https://github.com/codefordc/codefordc-website/assets/4806884/0c89057f-5f4f-4581-99c7-5a5bee49de7b">
using the docs at https://developers.google.com/maps/documentation/urls/get-started#search-action
the URL generated can instead look like:
`https://www.google.com/maps/search/?api=1&query=38.897682189941406%2C-77.02645874023438`
which goes to this page:
<img width="1224" alt="Screen Shot 2023-05-12 at 8 10 04 AM" src="https://github.com/codefordc/codefordc-website/assets/4806884/7abc426f-cda9-4203-ad2f-d1a03faac4c8">
what this PR implements and what i _think_ is the better option is to query on the place name and address, which is this link:
`https://www.google.com/maps/search/?api=1&query=Morning%20Consult%2C%201025%20F%20St%20NW%2C%20Washington%2C%20DC`
which goes to this page:
<img width="1227" alt="Screen Shot 2023-05-12 at 8 11 01 AM" src="https://github.com/codefordc/codefordc-website/assets/4806884/288bf154-f89c-425c-b396-64ead37f50ff">

