### PR TITLE
swap script for image for donation button

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -8,6 +8,10 @@ title: Donate to Code for DC
     <h1>Donate to Code for DC</h1>
     <p>Thank you for your interest in helping to support Code for DC! Contributions of any size are helpful and welcome.</p>
     <p>Donations to Code for DC are processed via <a href="https://opencollective.com/code-for-dc">Open Collective</a>, a platform where communities can collect and disburse money transparently, to sustain and grow their projects. Code for DC is hosted by the Open Collective Foundation 501(c)(3), and all donations are tax-deductible to the fullest extent of U.S. law.</p>
-    <script src="https://opencollective.com/code-for-dc/donate/button.js" color="blue"></script>
+    <div style="text-align:center">
+        <a href="https://opencollective.com/code-for-dc/donate" target="_blank">
+          <img src="https://opencollective.com/code-for-dc/donate/button@2x.png?color=blue" width=300 />
+        </a>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
donation button shows scroll bars on some browsers as noted in #44. this swaps the script for an image and link (an alternate method provided in the Open Collective docs). hoping this might resolve the issue? i can't test because i can't replicate the issue.